### PR TITLE
chore: package maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,18 +23,7 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
-    },
     "./package.json": "./package.json"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "dist/*.d.ts"
-      ]
-    }
   },
   "scripts": {
     "build": "rimraf dist && tsc",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "pnpm run build && ajs module test ."
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.2",
+    "@antelopejs/interface-core": "^0.0.3",
     "ioredis": "^5.10.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -45,8 +45,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -505,6 +505,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -1178,7 +1181,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.2':
+  '@antelopejs/interface-core@0.0.3':
     dependencies:
       reflect-metadata: 0.2.2
 
@@ -1478,7 +1481,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       giget: 1.2.5
       jiti: 1.21.7
@@ -1620,6 +1623,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -1701,7 +1706,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Remove wildcard subpath exports (`./*` and `typesVersions` wildcard) to hide internal dist paths from consumers
- Bump `@antelopejs/interface-core` dependency to `^0.0.3`

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs two maintenance tasks: it removes the wildcard subpath exports (`./*` and `typesVersions`) from `package.json` to prevent consumers from importing internal `dist/` paths directly, and it bumps the `@antelopejs/interface-core` peer dependency from `^0.0.2` to `^0.0.3`. The lock file is updated accordingly, including a transitive `defu` upgrade from `6.1.4` → `6.1.7`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are intentional and self-contained with no logic or correctness concerns.

Both changes are well-scoped: removing wildcard exports is an intentional encapsulation improvement, and the dependency bump is reflected correctly in the lock file. No P0 or P1 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Removes wildcard subpath exports (`./*` and `typesVersions`) to encapsulate internal dist paths, and bumps `@antelopejs/interface-core` from `^0.0.2` to `^0.0.3`. |
| pnpm-lock.yaml | Lock file updated to reflect the new `@antelopejs/interface-core@0.0.3` resolution and a transitive `defu` bump from `6.1.4` to `6.1.7`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer] -->|import '@antelopejs/interface-redis'| B["Public export: '.'<br/>(dist/index.js)"]
    A -->|import '@antelopejs/interface-redis/package.json'| C["package.json export"]
    A -. "removed: import './*'" .-> D["❌ dist/*.js<br/>(internal paths, now hidden)"]
    B --> E["@antelopejs/interface-core@0.0.3"]
    B --> F["ioredis@^5.10.1"]
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump @antelopejs/interface-core t..."](https://github.com/antelopejs/interface-redis/commit/585b59713c3d7edfc1e4821db0e4a67cb3eff389) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29166975)</sub>

<!-- /greptile_comment -->