### PR TITLE
chore(deps): interface-core as bounded peer + dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "test": "pnpm run build && ajs module test ."
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.3",
     "ioredis": "^5.10.1"
   },
   "devDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
@@ -52,6 +52,9 @@
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ importers:
 
   .:
     dependencies:
-      '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
     devDependencies:
+      '@antelopejs/interface-core':
+        specifier: '>=0.0.3 <1.0.0'
+        version: 0.0.3
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2


### PR DESCRIPTION
Move `@antelopejs/interface-core` from dependencies to peerDependencies (bounded to the current major, e.g. `>=0.0.5 <0.1.0`) and mirror it in devDependencies for standalone compilation. interface-core is a host-provided runtime singleton; this avoids dual installs and version-pinning overrides downstream. Verified: install, build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reclassifies `@antelopejs/interface-core` from a runtime `dependency` to a `peerDependency` (mirrored in `devDependencies`), which is the correct pattern for a host-provided singleton that should not be duplicated in the dependency tree.

- `@antelopejs/interface-core` is removed from `dependencies` and added to both `peerDependencies` and `devDependencies` with the range `>=0.0.3 <1.0.0`, allowing the host to control which version is used at runtime.
- The lockfile is updated accordingly; the resolved dev version remains `0.0.3`.
- The declared peer range upper bound (`<1.0.0`) is wider than the PR description's example (`<0.1.0`), which may be intentional but differs from the stated rationale of bounding to the current minor.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward dependency reclassification with no runtime logic altered.

The only change is moving a dependency to peerDependencies/devDependencies. No source code is modified, the lockfile resolves correctly, and the peer range covers the currently published version. The range upper bound is wider than the PR description's example, but this does not break anything today.

No files require special attention; both changed files are configuration only.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Moves @antelopejs/interface-core from dependencies to peerDependencies + devDependencies with range >=0.0.3 <1.0.0; removes it from runtime dependencies |
| pnpm-lock.yaml | Lockfile updated to reflect the move of @antelopejs/interface-core from dependencies to devDependencies; resolved version remains 0.0.3 |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Downstream consumer\ninstalls interface-redis"] --> B{Dependency type}
    B -->|"Before (dependency)"| C["npm/pnpm installs\ninterface-core@^0.0.3\ninto interface-redis node_modules"]
    B -->|"After (peerDependency)"| D["Host must provide\ninterface-core >=0.0.3 <1.0.0\nin its own node_modules"]
    C --> E["Risk: dual installs,\nversion overrides downstream"]
    D --> F["interface-core resolved\nonce from host tree"]
    F --> G["devDependencies: >=0.0.3 <1.0.0\n(for local build & CI)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Downstream consumer\ninstalls interface-redis"] --> B{Dependency type}
    B -->|"Before (dependency)"| C["npm/pnpm installs\ninterface-core@^0.0.3\ninto interface-redis node_modules"]
    B -->|"After (peerDependency)"| D["Host must provide\ninterface-core >=0.0.3 <1.0.0\nin its own node_modules"]
    C --> E["Risk: dual installs,\nversion overrides downstream"]
    D --> F["interface-core resolved\nonce from host tree"]
    F --> G["devDependencies: >=0.0.3 <1.0.0\n(for local build & CI)"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-redis/commit/1bbd6068c07c3ab91d95d5b2656283994d03a6c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37739138)</sub>

<!-- /greptile_comment -->